### PR TITLE
Fix lint warnings "[ValidateDocumentationComments]: change the parame…

### DIFF
--- a/Sources/XopenCore/Pathfinder.swift
+++ b/Sources/XopenCore/Pathfinder.swift
@@ -33,7 +33,7 @@ public final class Pathfinder {
 
     /// Initializer
     /// - Parameters:
-    ///   - ignoreDotDirectories: If it's ture, then ignores dot directories. Default value is `true`
+    ///   - ignoreDotDirectories: If it's ture, then ignores dot directories, default value is `true`
     ///   - xcodeFileExtensions: Support file types. Default value is `Pathfinder.defaultXcodeFileExtensions`
     public init(ignoreDotDirectories: Bool = true, xcodeFileExtensions: [String] = Pathfinder.defaultXcodeFileExtensions) {
         self.ignoreDotDirectories = ignoreDotDirectories
@@ -41,7 +41,7 @@ public final class Pathfinder {
     }
 
     /// Discover file under given direcotry
-    /// - Parameter rootDirectoryURL: Search root directory file URL.
+    /// - Parameter rootDirectoryURL: Search root directory file URL
     /// - Returns: URL found.
     /// - Throws: when not found.
     public func discoverFileURL(under rootDirectoryURL: URL) throws -> URL {

--- a/Sources/XopenCore/Xopen.swift
+++ b/Sources/XopenCore/Xopen.swift
@@ -24,9 +24,9 @@ public enum Xopen {
     /// Open a file by Xcode
     /// - Parameters:
     ///   - url: A file URL you want to open by Xcode
-    ///   - targetVersion: Xcode version you want to use.
-    ///   - fallbackVersion: Xcode version you want to use if no xcode-version.
-    /// - Returns: NSRunningApplication
+    ///   - targetVersion: Xcode version you want to use
+    ///   - fallbackVersion: Xcode version you want to use if no xcode-version
+    /// - Returns: NSRunningApplication.
     /// - Throws: error.
     @discardableResult
     public static func openXcode(with url: URL, targetVersion: UserSpecificXcodeVersion? = nil, fallbackVersion: UserSpecificXcodeVersion? = nil) throws -> NSRunningApplication {


### PR DESCRIPTION
Fix lint warnings "[ValidateDocumentationComments]: change the parameters of XXXX's documentation to match its parameters"

swift-format lint reports this warnings if parameters doc comments contains period in the middle of items.

I realized that I had to explain it in one sentence and avoid using periods.