### PR TITLE
decodes CFBundleVersion as String

### DIFF
--- a/Sources/XopenCore/InstalledXcode.swift
+++ b/Sources/XopenCore/InstalledXcode.swift
@@ -20,7 +20,7 @@ public final class InstalledXcode {
     }
 
     /// Version ex: 20503.0
-    public var version: Double {
+    public var version: String {
         return versionPlist.version
     }
 
@@ -92,7 +92,7 @@ extension InstalledXcode: Equatable, Comparable {
     }
 
     public static func < (lhs: InstalledXcode, rhs: InstalledXcode) -> Bool {
-        return lhs.version < rhs.version
+        return lhs.version.compare(rhs.version, options: .numeric) == .orderedAscending
     }
 }
 

--- a/Sources/XopenCore/VersionPlist.swift
+++ b/Sources/XopenCore/VersionPlist.swift
@@ -2,7 +2,7 @@ import Foundation
 
 struct VersionPlist: Decodable {
     let shortVersion: String
-    let version: Double
+    let version: String
     let buildVersion: String
 
     enum CodingKeys: String, CodingKey {
@@ -14,7 +14,7 @@ struct VersionPlist: Decodable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         shortVersion = try container.decode(String.self, forKey: .shortVersion)
-        version = try container.decode(Double.self, forKey: .version, transformFrom: String.self)
+        version = try container.decode(String.self, forKey: .version)
         buildVersion = try container.decode(String.self, forKey: .buildVersion)
     }
 }


### PR DESCRIPTION
Xcode 14 Beta’s CFBundleVersion is like ‘21257.0.0.0.22’ then it cannot be decode as Double.